### PR TITLE
security/step-certificates:0.15.6

### DIFF
--- a/patches/security.step-certificates.0.15.6.diff
+++ b/patches/security.step-certificates.0.15.6.diff
@@ -1,0 +1,235 @@
+diff --git a/security/step-certificates/Makefile b/security/step-certificates/Makefile
+index bc40eb2a7cb4..9290fd6a2325 100644
+--- a/security/step-certificates/Makefile
++++ b/security/step-certificates/Makefile
+@@ -2,7 +2,7 @@
+ 
+ PORTNAME=	step-certificates
+ DISTVERSIONPREFIX=v
+-DISTVERSION=	0.15.4
++DISTVERSION=	0.15.6
+ CATEGORIES=	security
+ 
+ MAINTAINER=	mw@wipp.bayern
+@@ -27,7 +27,7 @@ GH_TUPLE=	\
+ 		Masterminds:semver:v3.1.0:masterminds_semver_v3/vendor/github.com/Masterminds/semver/v3 \
+ 		Masterminds:sprig:v3.1.0:masterminds_sprig_v3/vendor/github.com/Masterminds/sprig/v3 \
+ 		aws:aws-sdk-go:v1.30.29:aws_aws_sdk_go/vendor/github.com/aws/aws-sdk-go \
+-		census-instrumentation:opencensus-go:v0.22.2:census_instrumentation_opencensus_go/vendor/go.opencensus.io \
++		census-instrumentation:opencensus-go:v0.22.5:census_instrumentation_opencensus_go/vendor/go.opencensus.io \
+ 		cespare:xxhash:v1.1.0:cespare_xxhash/vendor/github.com/cespare/xxhash \
+ 		chzyer:readline:2972be24d48e:chzyer_readline/vendor/github.com/chzyer/readline \
+ 		cpuguy83:go-md2man:v2.0.0:cpuguy83_go_md2man_v2/vendor/github.com/cpuguy83/go-md2man/v2 \
+@@ -38,49 +38,51 @@ GH_TUPLE=	\
+ 		dustin:go-humanize:v1.0.0:dustin_go_humanize/vendor/github.com/dustin/go-humanize \
+ 		etcd-io:bbolt:v1.3.2:etcd_io_bbolt/vendor/go.etcd.io/bbolt \
+ 		go-chi:chi:v4.0.2:go_chi_chi/vendor/github.com/go-chi/chi \
+-		go-piv:piv-go:cd2ae481f8d1:go_piv_piv_go/vendor/github.com/go-piv/piv-go \
++		go-piv:piv-go:v1.6.0:go_piv_piv_go/vendor/github.com/go-piv/piv-go \
+ 		go-sql-driver:mysql:v1.5.0:go_sql_driver_mysql/vendor/github.com/go-sql-driver/mysql \
+-		golang:appengine:v1.6.5:golang_appengine/vendor/google.golang.org/appengine \
+-		golang:crypto:123391ffb6de:golang_crypto/vendor/golang.org/x/crypto \
+-		golang:groupcache:215e87163ea7:golang_groupcache/vendor/github.com/golang/groupcache \
+-		golang:net:16171245cfb2:golang_net/vendor/golang.org/x/net \
+-		golang:oauth2:858c2ad4c8b6:golang_oauth2/vendor/golang.org/x/oauth2 \
+-		golang:protobuf:v1.3.2:golang_protobuf/vendor/github.com/golang/protobuf \
++		golang:appengine:v1.6.6:golang_appengine/vendor/google.golang.org/appengine \
++		golang:crypto:9e8e0b390897:golang_crypto/vendor/golang.org/x/crypto \
++		golang:groupcache:8c9f03a8e57e:golang_groupcache/vendor/github.com/golang/groupcache \
++		golang:mock:v1.4.4:golang_mock/vendor/github.com/golang/mock \
++		golang:net:f5854403a974:golang_net/vendor/golang.org/x/net \
++		golang:oauth2:5d25da1a8d43:golang_oauth2/vendor/golang.org/x/oauth2 \
++		golang:protobuf:v1.4.3:golang_protobuf/vendor/github.com/golang/protobuf \
+ 		golang:snappy:v0.0.1:golang_snappy/vendor/github.com/golang/snappy \
+-		golang:sys:b016eb3dc98e:golang_sys/vendor/golang.org/x/sys \
+-		golang:text:v0.3.2:golang_text/vendor/golang.org/x/text \
+-		google:go-cmp:v0.3.1:google_go_cmp/vendor/github.com/google/go-cmp \
+-		google:go-genproto:f3c370f40bfb:google_go_genproto/vendor/google.golang.org/genproto \
+-		google:uuid:v1.1.1:google_uuid/vendor/github.com/google/uuid \
++		golang:sys:fdedc70b468f:golang_sys/vendor/golang.org/x/sys \
++		golang:text:v0.3.3:golang_text/vendor/golang.org/x/text \
++		google:go-cmp:v0.5.2:google_go_cmp/vendor/github.com/google/go-cmp \
++		google:go-genproto:1ed22bb0c154:google_go_genproto/vendor/google.golang.org/genproto \
++		google:uuid:v1.1.2:google_uuid/vendor/github.com/google/uuid \
+ 		googleapis:gax-go:v2.0.5:googleapis_gax_go_v2/vendor/github.com/googleapis/gax-go \
+-		googleapis:google-api-go-client:v0.15.0:googleapis_google_api_go_client/vendor/google.golang.org/api \
+-		googleapis:google-cloud-go:v0.51.0:googleapis_google_cloud_go/vendor/cloud.google.com/go \
+-		grpc:grpc-go:v1.26.0:grpc_grpc_go/vendor/google.golang.org/grpc \
++		googleapis:google-api-go-client:v0.33.0:googleapis_google_api_go_client/vendor/google.golang.org/api \
++		googleapis:google-cloud-go:v0.70.0:googleapis_google_cloud_go/vendor/cloud.google.com/go \
++		grpc:grpc-go:v1.32.0:grpc_grpc_go/vendor/google.golang.org/grpc \
+ 		huandu:xstrings:v1.3.1:huandu_xstrings/vendor/github.com/huandu/xstrings \
+ 		imdario:mergo:v0.3.8:imdario_mergo/vendor/github.com/imdario/mergo \
+ 		jmespath:go-jmespath:v0.3.0:jmespath_go_jmespath/vendor/github.com/jmespath/go-jmespath \
+ 		juju:ansiterm:720a0952cc2a:juju_ansiterm/vendor/github.com/juju/ansiterm \
+ 		konsorten:go-windows-terminal-sequences:v1.0.2:konsorten_go_windows_terminal_sequences/vendor/github.com/konsorten/go-windows-terminal-sequences \
+ 		lunixbochs:vtclean:v1.0.0:lunixbochs_vtclean/vendor/github.com/lunixbochs/vtclean \
+-		manifoldco:promptui:v0.3.1:manifoldco_promptui/vendor/github.com/manifoldco/promptui \
++		manifoldco:promptui:v0.8.0:manifoldco_promptui/vendor/github.com/manifoldco/promptui \
+ 		mattn:go-colorable:v0.1.4:mattn_go_colorable/vendor/github.com/mattn/go-colorable \
+ 		mattn:go-isatty:v0.0.11:mattn_go_isatty/vendor/github.com/mattn/go-isatty \
+ 		mitchellh:copystructure:v1.0.0:mitchellh_copystructure/vendor/github.com/mitchellh/copystructure \
+ 		mitchellh:reflectwalk:v1.0.0:mitchellh_reflectwalk/vendor/github.com/mitchellh/reflectwalk \
+ 		newrelic:go-agent:v2.15.0:newrelic_go_agent/vendor/github.com/newrelic/go-agent \
+ 		pkg:errors:v0.9.1:pkg_errors/vendor/github.com/pkg/errors \
++		protocolbuffers:protobuf-go:v1.25.0:protocolbuffers_protobuf_go/vendor/google.golang.org/protobuf \
+ 		rs:xid:v1.2.1:rs_xid/vendor/github.com/rs/xid \
+ 		russross:blackfriday:v2.0.1:russross_blackfriday_v2/vendor/github.com/russross/blackfriday/v2 \
+ 		samfoo:ansi:b6bd2ded7189:samfoo_ansi/vendor/github.com/samfoo/ansi \
+ 		shurcooL:sanitized_anchor_name:v1.0.0:shurcool_sanitized_anchor_name/vendor/github.com/shurcooL/sanitized_anchor_name \
+ 		sirupsen:logrus:v1.4.2:sirupsen_logrus/vendor/github.com/sirupsen/logrus \
+ 		smallstep:assert:82e2b9b3b262:smallstep_assert/vendor/github.com/smallstep/assert \
+-		smallstep:cli:v0.15.0:smallstep_cli/vendor/github.com/smallstep/cli \
+-		smallstep:crypto:v0.6.0:smallstep_crypto/vendor/go.step.sm/crypto \
++		smallstep:cli-utils:v0.1.0:smallstep_cli_utils/vendor/go.step.sm/cli-utils \
++		smallstep:crypto:v0.7.3:smallstep_crypto/vendor/go.step.sm/crypto \
+ 		smallstep:nosql:v0.3.0:smallstep_nosql/vendor/github.com/smallstep/nosql \
+ 		spf13:cast:v1.3.1:spf13_cast/vendor/github.com/spf13/cast \
+ 		square:go-jose:v2.5.1:square_go_jose/vendor/gopkg.in/square/go-jose.v2 \
+-		urfave:cli:v1.22.2:urfave_cli/vendor/github.com/urfave/cli
++		urfave:cli:v1.22.4:urfave_cli/vendor/github.com/urfave/cli
+ 
+ USE_RC_SUBR=	step-ca
+ 
+diff --git a/security/step-certificates/distinfo b/security/step-certificates/distinfo
+index a1b097d6f76c..95e80d435da7 100644
+--- a/security/step-certificates/distinfo
++++ b/security/step-certificates/distinfo
+@@ -1,6 +1,6 @@
+-TIMESTAMP = 1599658401
+-SHA256 (smallstep-certificates-v0.15.4_GH0.tar.gz) = 4d0645af1163137c7e2ed610528e4add5b9aee0a5405f33ca19335fd49061c95
+-SIZE (smallstep-certificates-v0.15.4_GH0.tar.gz) = 17588636
++TIMESTAMP = 1608494220
++SHA256 (smallstep-certificates-v0.15.6_GH0.tar.gz) = 49f712cd065d270ebadfcf06b13edc876938a40792bafc181703f939300a981b
++SIZE (smallstep-certificates-v0.15.6_GH0.tar.gz) = 17625708
+ SHA256 (AndreasBriese-bbloom-e2d15f34fcf9_GH0.tar.gz) = e88bd873a2251d70b5d2cbf9dceff24fa25ca5652ac1f99165c303e98df494a1
+ SIZE (AndreasBriese-bbloom-e2d15f34fcf9_GH0.tar.gz) = 7704
+ SHA256 (DataDog-zstd-v1.4.1_GH0.tar.gz) = 48c0ad82d9bc66d77ca95aa47374bed6b6466510da66a2b2f9215cb239cb8137
+@@ -13,8 +13,8 @@ SHA256 (Masterminds-sprig-v3.1.0_GH0.tar.gz) = a9e5031c3891ce95e799c5b07de9572ee
+ SIZE (Masterminds-sprig-v3.1.0_GH0.tar.gz) = 49979
+ SHA256 (aws-aws-sdk-go-v1.30.29_GH0.tar.gz) = 3aa755cbe1137f6bcf29c13eb1cd539b380864ba6cda35565b3224cc448958e5
+ SIZE (aws-aws-sdk-go-v1.30.29_GH0.tar.gz) = 14813782
+-SHA256 (census-instrumentation-opencensus-go-v0.22.2_GH0.tar.gz) = 0aa930142b669d7c47e2b8343f6adc9f03414a9c45763c5f746de95231d6ad6d
+-SIZE (census-instrumentation-opencensus-go-v0.22.2_GH0.tar.gz) = 165321
++SHA256 (census-instrumentation-opencensus-go-v0.22.5_GH0.tar.gz) = 881df0d24a0df8afacd2228d4987252f742061fe8eeb5f14cc9e3f32b7c357be
++SIZE (census-instrumentation-opencensus-go-v0.22.5_GH0.tar.gz) = 171403
+ SHA256 (cespare-xxhash-v1.1.0_GH0.tar.gz) = 9418be390574092f0ca989b9ae2f5450270ead8125a635a100850b28c8c9c495
+ SIZE (cespare-xxhash-v1.1.0_GH0.tar.gz) = 8200
+ SHA256 (chzyer-readline-2972be24d48e_GH0.tar.gz) = 8f425cfb33fce61a137866c0a88117c68f49de79a61a341353fc97339c6b74da
+@@ -35,42 +35,44 @@ SHA256 (etcd-io-bbolt-v1.3.2_GH0.tar.gz) = 0f4bd88cce84f7b42f6364fc8c77ae7dd7d2f
+ SIZE (etcd-io-bbolt-v1.3.2_GH0.tar.gz) = 93921
+ SHA256 (go-chi-chi-v4.0.2_GH0.tar.gz) = 7713a5afd18c440f38e67f853f5ded4f039f08f239dc6a29ed2788be5caaae99
+ SIZE (go-chi-chi-v4.0.2_GH0.tar.gz) = 67748
+-SHA256 (go-piv-piv-go-cd2ae481f8d1_GH0.tar.gz) = 27a63c314c3c3006ff3826b1864cfea368da8405ddf33072cc6d3f9c0cacb455
+-SIZE (go-piv-piv-go-cd2ae481f8d1_GH0.tar.gz) = 33766
++SHA256 (go-piv-piv-go-v1.6.0_GH0.tar.gz) = 10ffae39ef894cd268783112cbb1d7f6c5292a698f111e2e5a357f5442a41cb5
++SIZE (go-piv-piv-go-v1.6.0_GH0.tar.gz) = 34995
+ SHA256 (go-sql-driver-mysql-v1.5.0_GH0.tar.gz) = 9d98b46623037447a26a51a203540bf605b6e6220d31f2efc7396242fcb660b5
+ SIZE (go-sql-driver-mysql-v1.5.0_GH0.tar.gz) = 90474
+-SHA256 (golang-appengine-v1.6.5_GH0.tar.gz) = 4e7df5d4ec2dda0f59f26925b36a087843fd1a165adb938712068376bf791316
+-SIZE (golang-appengine-v1.6.5_GH0.tar.gz) = 332903
+-SHA256 (golang-crypto-123391ffb6de_GH0.tar.gz) = 09cadc5885fb57e7c3e3cdfd245a4dffb103adc90eb7f97efbc106905293c538
+-SIZE (golang-crypto-123391ffb6de_GH0.tar.gz) = 1732577
+-SHA256 (golang-groupcache-215e87163ea7_GH0.tar.gz) = 500b097a42fb5c0cd516f1bb56e9c745ba6c1c910b4dc7296aea2b9120ee5e70
+-SIZE (golang-groupcache-215e87163ea7_GH0.tar.gz) = 26040
+-SHA256 (golang-net-16171245cfb2_GH0.tar.gz) = 941e5a2afb85a131b42f8503fe1a760447a40a0f26539c11ca489f4f24a77e77
+-SIZE (golang-net-16171245cfb2_GH0.tar.gz) = 1172446
+-SHA256 (golang-oauth2-858c2ad4c8b6_GH0.tar.gz) = 28ae6a15793d97ba980dd318dba21167dd751ca8bbafcb69ffa648b41c7cbf48
+-SIZE (golang-oauth2-858c2ad4c8b6_GH0.tar.gz) = 45265
+-SHA256 (golang-protobuf-v1.3.2_GH0.tar.gz) = c9cda622857a17cf0877c5ba76688a931883e505f40744c9495638b6e3da1f65
+-SIZE (golang-protobuf-v1.3.2_GH0.tar.gz) = 312285
++SHA256 (golang-appengine-v1.6.6_GH0.tar.gz) = 0c3d1e1c7ba0b97ea3457ddd169aac0667dbbb8c8d81e011632751f75bfbb624
++SIZE (golang-appengine-v1.6.6_GH0.tar.gz) = 332981
++SHA256 (golang-crypto-9e8e0b390897_GH0.tar.gz) = 79bd9db71da6ec75f3df7b7e43aeb90983227058ce9b8d0f08405a141768b3c3
++SIZE (golang-crypto-9e8e0b390897_GH0.tar.gz) = 1732662
++SHA256 (golang-groupcache-8c9f03a8e57e_GH0.tar.gz) = b92f918daa48048fd360f14d1a4aed6e70c1176ae6b00b0dc04094bb088e9865
++SIZE (golang-groupcache-8c9f03a8e57e_GH0.tar.gz) = 26047
++SHA256 (golang-mock-v1.4.4_GH0.tar.gz) = a3e25a2c234f82f6685e143681e223462bd1cc0098375a48dc042e227f2cd677
++SIZE (golang-mock-v1.4.4_GH0.tar.gz) = 55141
++SHA256 (golang-net-f5854403a974_GH0.tar.gz) = 75e94d61e00b4aec6b7baea0927e51a92239caf876214f45394258855c73f92f
++SIZE (golang-net-f5854403a974_GH0.tar.gz) = 1178323
++SHA256 (golang-oauth2-5d25da1a8d43_GH0.tar.gz) = 359a1ce0493a717f0d30e964d6ebfedca99becdd188383c4853a5010ffc36feb
++SIZE (golang-oauth2-5d25da1a8d43_GH0.tar.gz) = 59450
++SHA256 (golang-protobuf-v1.4.3_GH0.tar.gz) = 5736f943f8647362f5559689df6154f3c85d261fb088867c8a68494e2a767610
++SIZE (golang-protobuf-v1.4.3_GH0.tar.gz) = 171969
+ SHA256 (golang-snappy-v0.0.1_GH0.tar.gz) = b1d97f47fcb61cb0cdd54bc424eda980c47838effb0ec9e322506514a50fee85
+ SIZE (golang-snappy-v0.0.1_GH0.tar.gz) = 62605
+-SHA256 (golang-sys-b016eb3dc98e_GH0.tar.gz) = 09d8ddfb8f2c651e956a534d5de1e5401567d12dd0a589abd4ad5e9fa4213b06
+-SIZE (golang-sys-b016eb3dc98e_GH0.tar.gz) = 1535262
+-SHA256 (golang-text-v0.3.2_GH0.tar.gz) = 0b9309698f5708531c5377ab1e29b423a6d9e20c55a8d386c3b8283428212f22
+-SIZE (golang-text-v0.3.2_GH0.tar.gz) = 7168069
+-SHA256 (google-go-cmp-v0.3.1_GH0.tar.gz) = a95fa266e5c2283b813102f265c1bdf5b78100f9889b984aef828eb094efe6e3
+-SIZE (google-go-cmp-v0.3.1_GH0.tar.gz) = 76403
+-SHA256 (google-go-genproto-f3c370f40bfb_GH0.tar.gz) = 754588f44bdfdbe4521ad0950375a0357f2454ff6de43e0e6d6a88b5b5182c55
+-SIZE (google-go-genproto-f3c370f40bfb_GH0.tar.gz) = 5857725
+-SHA256 (google-uuid-v1.1.1_GH0.tar.gz) = bebd4b0b4ea152a9793615ef23c83f688876d8c284a2092264d20a4bf4ffc423
+-SIZE (google-uuid-v1.1.1_GH0.tar.gz) = 13543
++SHA256 (golang-sys-fdedc70b468f_GH0.tar.gz) = dbb02cdcafaa32d9d2cd0c16b7204fbb044512bc38814cb1ee5673a9ab2f2929
++SIZE (golang-sys-fdedc70b468f_GH0.tar.gz) = 1064136
++SHA256 (golang-text-v0.3.3_GH0.tar.gz) = 1604233637e3593749fbbb13b5069b08e6feba6d2b55a02fd3148793d5871185
++SIZE (golang-text-v0.3.3_GH0.tar.gz) = 7747332
++SHA256 (google-go-cmp-v0.5.2_GH0.tar.gz) = 76e0c4238e7fec1490ef2c8b4719a024ade7f4b8778965acb888566535ee9dd5
++SIZE (google-go-cmp-v0.5.2_GH0.tar.gz) = 99769
++SHA256 (google-go-genproto-1ed22bb0c154_GH0.tar.gz) = 0109cd79237f6e4d1338be801d28226183d4dc8fcf9c63e9ab526bc122d767c6
++SIZE (google-go-genproto-1ed22bb0c154_GH0.tar.gz) = 13363597
++SHA256 (google-uuid-v1.1.2_GH0.tar.gz) = e650558e314307cf33391d0a9ef575b418188206d61cb9751e9f11bceb0874d0
++SIZE (google-uuid-v1.1.2_GH0.tar.gz) = 13871
+ SHA256 (googleapis-gax-go-v2.0.5_GH0.tar.gz) = 3089affe6f5e27f7a6d494cb399aa6baf232384f763f548ad5ddfbea0e88e59c
+ SIZE (googleapis-gax-go-v2.0.5_GH0.tar.gz) = 15328
+-SHA256 (googleapis-google-api-go-client-v0.15.0_GH0.tar.gz) = 6d628266b507a71f26ce2fd426758e1241f9dd94458752d9d12a0b09da983844
+-SIZE (googleapis-google-api-go-client-v0.15.0_GH0.tar.gz) = 13259795
+-SHA256 (googleapis-google-cloud-go-v0.51.0_GH0.tar.gz) = efee71ab4baf86277c6ceec4633dd606595e4b0fa299c22863dbeb03eed65941
+-SIZE (googleapis-google-cloud-go-v0.51.0_GH0.tar.gz) = 2441854
+-SHA256 (grpc-grpc-go-v1.26.0_GH0.tar.gz) = a594cbd8f7d545d181c92b27aafd5d4824459e3a729a8bd67a0c8b99c411f05a
+-SIZE (grpc-grpc-go-v1.26.0_GH0.tar.gz) = 765416
++SHA256 (googleapis-google-api-go-client-v0.33.0_GH0.tar.gz) = c73839f4146fd47bc211629ee9f42069456e4621d641bdff4791b7cb14bfbf74
++SIZE (googleapis-google-api-go-client-v0.33.0_GH0.tar.gz) = 16652265
++SHA256 (googleapis-google-cloud-go-v0.70.0_GH0.tar.gz) = 138cb6811fc1012bfbcffbb419494e4355b104bba0583aeedfcdcba7da73fa89
++SIZE (googleapis-google-cloud-go-v0.70.0_GH0.tar.gz) = 3076427
++SHA256 (grpc-grpc-go-v1.32.0_GH0.tar.gz) = 47a991a1d561738839e74803e350a276b4b753ae4af329091cb35ad2a117dcb2
++SIZE (grpc-grpc-go-v1.32.0_GH0.tar.gz) = 1053458
+ SHA256 (huandu-xstrings-v1.3.1_GH0.tar.gz) = d399f03735391073441145bac6b8d06b36f3b59e005db77ebafde130ddf215bf
+ SIZE (huandu-xstrings-v1.3.1_GH0.tar.gz) = 17797
+ SHA256 (imdario-mergo-v0.3.8_GH0.tar.gz) = 8722e1280a333b1b17541dc05102200e1c9e8ee85f45fc66a4ba629b97a870e6
+@@ -83,8 +85,8 @@ SHA256 (konsorten-go-windows-terminal-sequences-v1.0.2_GH0.tar.gz) = e61f6422c7d
+ SIZE (konsorten-go-windows-terminal-sequences-v1.0.2_GH0.tar.gz) = 1987
+ SHA256 (lunixbochs-vtclean-v1.0.0_GH0.tar.gz) = 38aa5c60284f77cbb4be1de4af8907ce66954ff1a11e4f910d02e0283ce13b33
+ SIZE (lunixbochs-vtclean-v1.0.0_GH0.tar.gz) = 4213
+-SHA256 (manifoldco-promptui-v0.3.1_GH0.tar.gz) = 8860f2166c1913b2f66d4e8992957128037cc8c9495f225208c8462d1b0236cc
+-SIZE (manifoldco-promptui-v0.3.1_GH0.tar.gz) = 22986
++SHA256 (manifoldco-promptui-v0.8.0_GH0.tar.gz) = 3ef92d9991f3fe9fa85bdeb8546ae5b2c81a5a478c6ebcf356b2a6c25a59f219
++SIZE (manifoldco-promptui-v0.8.0_GH0.tar.gz) = 26830
+ SHA256 (mattn-go-colorable-v0.1.4_GH0.tar.gz) = 157806ad8125e6bef4d9b58c9125ccb98a8343136f93faf442ab0cc6e7c24c11
+ SIZE (mattn-go-colorable-v0.1.4_GH0.tar.gz) = 8981
+ SHA256 (mattn-go-isatty-v0.0.11_GH0.tar.gz) = 631fab18253998a4e27e9d260c445e9852bd86cf5a42693623d305c3e59c415a
+@@ -97,6 +99,8 @@ SHA256 (newrelic-go-agent-v2.15.0_GH0.tar.gz) = 128096c8ac96e6cfd099aa359f46f0d8
+ SIZE (newrelic-go-agent-v2.15.0_GH0.tar.gz) = 350696
+ SHA256 (pkg-errors-v0.9.1_GH0.tar.gz) = 56bfd893023daa498508bfe161de1be83299fcf15376035e7df79cbd7d6fa608
+ SIZE (pkg-errors-v0.9.1_GH0.tar.gz) = 13415
++SHA256 (protocolbuffers-protobuf-go-v1.25.0_GH0.tar.gz) = c1c04d6e36c0d0fb6f3374197f9025d7e6df13f38a974098be020617c00fbaf2
++SIZE (protocolbuffers-protobuf-go-v1.25.0_GH0.tar.gz) = 1258804
+ SHA256 (rs-xid-v1.2.1_GH0.tar.gz) = bb207227d5ae99bda71d38ae11e29b822c9b572223781bc282ad2f8e69002f2c
+ SIZE (rs-xid-v1.2.1_GH0.tar.gz) = 9553
+ SHA256 (russross-blackfriday-v2.0.1_GH0.tar.gz) = 5a0f38a36b6f3b2d59b72d713451a895a4d3a4406b3533882483782e37797cff
+@@ -109,15 +113,15 @@ SHA256 (sirupsen-logrus-v1.4.2_GH0.tar.gz) = 67f2ddf467b7e63d2d2529d227946a331e2
+ SIZE (sirupsen-logrus-v1.4.2_GH0.tar.gz) = 41373
+ SHA256 (smallstep-assert-82e2b9b3b262_GH0.tar.gz) = 6c19763fe97ee07940c12a5ed7693865146e90ab6862deea4f5e907cac7d4880
+ SIZE (smallstep-assert-82e2b9b3b262_GH0.tar.gz) = 4069
+-SHA256 (smallstep-cli-v0.15.0_GH0.tar.gz) = 529395d44932f405867fde83f0a4b07831435661e08cd98ad4dad6f3e3175925
+-SIZE (smallstep-cli-v0.15.0_GH0.tar.gz) = 476916
+-SHA256 (smallstep-crypto-v0.6.0_GH0.tar.gz) = f5de2fcd3661f821b1926989baff0e4194d3130a321a1612687ec739ecf9bd9d
+-SIZE (smallstep-crypto-v0.6.0_GH0.tar.gz) = 133163
++SHA256 (smallstep-cli-utils-v0.1.0_GH0.tar.gz) = 75db45e39e8785b66ba04d5d950d54bb44a5d913a89529f2e980805636b65ee8
++SIZE (smallstep-cli-utils-v0.1.0_GH0.tar.gz) = 133896
++SHA256 (smallstep-crypto-v0.7.3_GH0.tar.gz) = 86053d1e0390dc800441a22ed5c0a974b8f60f3a6d188ae24db6096a5f039a47
++SIZE (smallstep-crypto-v0.7.3_GH0.tar.gz) = 133986
+ SHA256 (smallstep-nosql-v0.3.0_GH0.tar.gz) = 6020dc16800b55f6fd83be95e0e5c9d0d1ed4aee530a3510e06cd8ce7aa4b470
+ SIZE (smallstep-nosql-v0.3.0_GH0.tar.gz) = 21961
+ SHA256 (spf13-cast-v1.3.1_GH0.tar.gz) = 4fa8d06903b490ae6f1316e55c5446d5648eea2b450671ebc54d4bbe79bc46b1
+ SIZE (spf13-cast-v1.3.1_GH0.tar.gz) = 11102
+ SHA256 (square-go-jose-v2.5.1_GH0.tar.gz) = 74c65592183c542b254eb2933f7a99ee869abdf9e7ac02aad4d9f0dce980ace8
+ SIZE (square-go-jose-v2.5.1_GH0.tar.gz) = 309860
+-SHA256 (urfave-cli-v1.22.2_GH0.tar.gz) = 38a93b363b3d668506fa094937cd8b81dde333c74b59388cecf95443c8cdabf3
+-SIZE (urfave-cli-v1.22.2_GH0.tar.gz) = 76132
++SHA256 (urfave-cli-v1.22.4_GH0.tar.gz) = 83d628fdd261accd4dc0b232bfc8ff06e734ec5137e134a8cee916693a8bb117
++SIZE (urfave-cli-v1.22.4_GH0.tar.gz) = 78034


### PR DESCRIPTION
security/step-certificates: Update to 0.15.6

PR: 252004
Submitted by: Markus Wipp <mw@wipp.bayern>
Approved by: lwhsu
