### PR TITLE
devel/R-cran-rversions:2.0.2

### DIFF
--- a/patches/devel.R-cran-rversions.2.0.2.diff
+++ b/patches/devel.R-cran-rversions.2.0.2.diff
@@ -1,0 +1,59 @@
+diff --git a/devel/Makefile b/devel/Makefile
+index c155877b05eb..fd1db598847b 100644
+--- a/devel/Makefile
++++ b/devel/Makefile
+@@ -85,6 +85,7 @@
+     SUBDIR += R-cran-rngtools
+     SUBDIR += R-cran-rprojroot
+     SUBDIR += R-cran-rstudioapi
++    SUBDIR += R-cran-rversions
+     SUBDIR += R-cran-sfsmisc
+     SUBDIR += R-cran-sourcetools
+     SUBDIR += R-cran-sys
+diff --git a/devel/R-cran-rversions/Makefile b/devel/R-cran-rversions/Makefile
+new file mode 100644
+index 000000000000..b8d08725974c
+--- /dev/null
++++ b/devel/R-cran-rversions/Makefile
+@@ -0,0 +1,21 @@
++# $FreeBSD$
++# Created by: Guangyuan Yang <ygy@FreeBSD.org>
++
++PORTNAME=	rversions
++DISTVERSION=	2.0.2
++CATEGORIES=	devel
++DISTNAME=	${PORTNAME}_${DISTVERSION}
++
++MAINTAINER=	ygy@FreeBSD.org
++COMMENT=	Query 'R' Versions, Including 'r-release' and 'r-oldrel'
++
++LICENSE=	MIT
++LICENSE_FILE=	${WRKSRC}/LICENSE
++
++RUN_DEPENDS=	R-cran-curl>0:ftp/R-cran-curl \
++		R-cran-xml2>=1.0.0:textproc/R-cran-xml2
++TEST_DEPENDS=	R-cran-testthat>0:devel/R-cran-testthat
++
++USES=		cran:auto-plist
++
++.include <bsd.port.mk>
+diff --git a/devel/R-cran-rversions/distinfo b/devel/R-cran-rversions/distinfo
+new file mode 100644
+index 000000000000..a6614d4c6671
+--- /dev/null
++++ b/devel/R-cran-rversions/distinfo
+@@ -0,0 +1,3 @@
++TIMESTAMP = 1609524021
++SHA256 (rversions_2.0.2.tar.gz) = 3523f4b7393365341d429500b01ba3a224056e89d134635b81dfb4918ba2173e
++SIZE (rversions_2.0.2.tar.gz) = 41558
+diff --git a/devel/R-cran-rversions/pkg-descr b/devel/R-cran-rversions/pkg-descr
+new file mode 100644
+index 000000000000..a62f60d3d5b1
+--- /dev/null
++++ b/devel/R-cran-rversions/pkg-descr
+@@ -0,0 +1,5 @@
++Query the main 'R' 'SVN' repository to find the versions 'r-release' and
++'r-oldrel' refer to, and also all previous 'R' versions and their release
++dates.
++
++WWW: https://github.com/r-hub/rversions


### PR DESCRIPTION
new port: devel/R-cran-rversions: Query 'R' Versions, Including 'r-release' and 'r-oldrel'

Approved by: lwhsu