### PR TITLE
devel/R-cran-mockery:0.4.2

### DIFF
--- a/patches/devel.R-cran-mockery.0.4.2.diff
+++ b/patches/devel.R-cran-mockery.0.4.2.diff
@@ -1,0 +1,64 @@
+diff --git a/devel/Makefile b/devel/Makefile
+index 26f9e6a1c270..f2f9186ae684 100644
+--- a/devel/Makefile
++++ b/devel/Makefile
+@@ -62,6 +62,7 @@
+     SUBDIR += R-cran-magrittr
+     SUBDIR += R-cran-memoise
+     SUBDIR += R-cran-microbenchmark
++    SUBDIR += R-cran-mockery
+     SUBDIR += R-cran-optparse
+     SUBDIR += R-cran-pillar
+     SUBDIR += R-cran-pkgconfig
+diff --git a/devel/R-cran-mockery/Makefile b/devel/R-cran-mockery/Makefile
+new file mode 100644
+index 000000000000..39375525f56b
+--- /dev/null
++++ b/devel/R-cran-mockery/Makefile
+@@ -0,0 +1,23 @@
++# Created by: Guangyuan Yang <ygy@FreeBSD.org>
++# $FreeBSD$
++
++PORTNAME=	mockery
++DISTVERSION=	0.4.2
++CATEGORIES=	devel
++DISTNAME=	${PORTNAME}_${DISTVERSION}
++
++MAINTAINER=	ygy@FreeBSD.org
++COMMENT=	Mocking Library for R
++
++LICENSE=	MIT
++LICENSE_FILE=	${WRKSRC}/LICENSE
++
++BUILD_DEPENDS=	R-cran-knitr>0:print/R-cran-knitr
++RUN_DEPENDS=	R-cran-testthat>0:devel/R-cran-testthat
++TEST_DEPENDS=	R-cran-R6>0:devel/R-cran-R6 \
++		R-cran-knitr>0:print/R-cran-knitr \
++		R-cran-rmarkdown>=1.0:textproc/R-cran-rmarkdown
++
++USES=		cran:auto-plist
++
++.include <bsd.port.mk>
+diff --git a/devel/R-cran-mockery/distinfo b/devel/R-cran-mockery/distinfo
+new file mode 100644
+index 000000000000..d0cbac8e421b
+--- /dev/null
++++ b/devel/R-cran-mockery/distinfo
+@@ -0,0 +1,3 @@
++TIMESTAMP = 1609807522
++SHA256 (mockery_0.4.2.tar.gz) = 988e249c366ee7faf277de004084cf5ca24b5c8a8c6e3842f1b1362ce2f7ea9b
++SIZE (mockery_0.4.2.tar.gz) = 19837
+diff --git a/devel/R-cran-mockery/pkg-descr b/devel/R-cran-mockery/pkg-descr
+new file mode 100644
+index 000000000000..aac8d58321b2
+--- /dev/null
++++ b/devel/R-cran-mockery/pkg-descr
+@@ -0,0 +1,8 @@
++The two main functionalities of this package are creating mock objects
++(functions) and selectively intercepting calls to a given function that
++originate in some other function. It can be used with any testing framework
++available for R. Mock objects can be injected with either this package's own
++stub() function or a similar with_mock() facility present in the 'testthat'
++package.
++
++WWW: https://github.com/jfiksel/mockery


### PR DESCRIPTION
```
new port: devel/R-cran-mockery: Mocking Library for R

Approved by: lwhsu
```