### PR TITLE
devel/R-cran-pkgbuild:1.2.0

### DIFF
--- a/patches/devel.R-cran-pkgbuild.1.2.0.diff
+++ b/patches/devel.R-cran-pkgbuild.1.2.0.diff
@@ -1,0 +1,65 @@
+diff --git a/devel/Makefile b/devel/Makefile
+index 26f9e6a1c270..0252cf4b0678 100644
+--- a/devel/Makefile
++++ b/devel/Makefile
+@@ -64,6 +64,7 @@
+     SUBDIR += R-cran-microbenchmark
+     SUBDIR += R-cran-optparse
+     SUBDIR += R-cran-pillar
++    SUBDIR += R-cran-pkgbuild
+     SUBDIR += R-cran-pkgconfig
+     SUBDIR += R-cran-pkgmaker
+     SUBDIR += R-cran-plogr
+diff --git a/devel/R-cran-pkgbuild/Makefile b/devel/R-cran-pkgbuild/Makefile
+new file mode 100644
+index 000000000000..921898ac5979
+--- /dev/null
++++ b/devel/R-cran-pkgbuild/Makefile
+@@ -0,0 +1,27 @@
++# Created by: Guangyuan Yang <ygy@FreeBSD.org>
++# $FreeBSD$
++
++PORTNAME=	pkgbuild
++DISTVERSION=	1.2.0
++CATEGORIES=	devel
++DISTNAME=	${PORTNAME}_${DISTVERSION}
++
++MAINTAINER=	ygy@FreeBSD.org
++COMMENT=	Find Tools Needed to Build R Packages
++
++LICENSE=	MIT
++LICENSE_FILE=	${WRKSRC}/LICENSE
++
++RUN_DEPENDS=	R-cran-R6>0:devel/R-cran-R6 \
++		R-cran-callr>=3.2.0:devel/R-cran-callr \
++		R-cran-cli>0:devel/R-cran-cli \
++		R-cran-crayon>0:devel/R-cran-crayon \
++		R-cran-desc>0:devel/R-cran-desc \
++		R-cran-prettyunits>0:devel/R-cran-prettyunits \
++		R-cran-rprojroot>0:devel/R-cran-rprojroot \
++		R-cran-withr>=2.1.2:devel/R-cran-withr
++TEST_DEPENDS=	R-cran-Rcpp>0:devel/R-cran-Rcpp
++
++USES=		cran:auto-plist
++
++.include <bsd.port.mk>
+diff --git a/devel/R-cran-pkgbuild/distinfo b/devel/R-cran-pkgbuild/distinfo
+new file mode 100644
+index 000000000000..8d2c392456c9
+--- /dev/null
++++ b/devel/R-cran-pkgbuild/distinfo
+@@ -0,0 +1,3 @@
++TIMESTAMP = 1609807604
++SHA256 (pkgbuild_1.2.0.tar.gz) = 2e19308d3271fefd5e118c6d132d6a2511253b903620b5417892c72d2010a963
++SIZE (pkgbuild_1.2.0.tar.gz) = 30383
+diff --git a/devel/R-cran-pkgbuild/pkg-descr b/devel/R-cran-pkgbuild/pkg-descr
+new file mode 100644
+index 000000000000..d148c2736985
+--- /dev/null
++++ b/devel/R-cran-pkgbuild/pkg-descr
+@@ -0,0 +1,5 @@
++Provides functions used to build R packages. Locates compilers needed to build
++R packages on various platforms and ensures the PATH is configured
++appropriately so R can use them.
++
++WWW: https://github.com/r-lib/pkgbuild


### PR DESCRIPTION
```
new port: devel/R-cran-pkgbuild: Find Tools Needed to Build R Packages

Approved by: lwhsu
```