### PR TITLE
x11/xssstate:1.1

### DIFF
--- a/patches/x11.xssstate.1.1.diff
+++ b/patches/x11.xssstate.1.1.diff
@@ -1,0 +1,50 @@
+diff --git a/x11/xssstate/Makefile b/x11/xssstate/Makefile
+new file mode 100644
+index 000000000000..86dc50e23aba
+--- /dev/null
++++ b/x11/xssstate/Makefile
+@@ -0,0 +1,24 @@
++# $FreeBSD$
++
++PORTNAME=	xssstate
++PORTVERSION=	1.1
++CATEGORIES=	x11
++MASTER_SITES=	https://dl.suckless.org/tools/
++
++MAINTAINER=	kfv@kfv.io
++COMMENT=	Simple tool to retrieve the X screensaver state
++
++LICENSE=	MIT
++LICENSE_FILE=	${WRKSRC}/LICENSE
++
++USES=		localbase:ldflags xorg
++USE_XORG=	x11 xscrnsaver
++
++MAKE_ARGS=	LDFLAGS="${LDFLAGS}" CFLAGS="${CFLAGS}" CC="${CC}"
++
++CFLAGS+=	-std=c99 -Wall -DVERSION=\\\"${PORTVERSION}\\\"
++LDFLAGS+=	-lX11 -lXss
++
++PLIST_FILES=	bin/${PORTNAME} share/man/man1/${PORTNAME}.1.gz
++
++.include <bsd.port.mk>
+diff --git a/x11/xssstate/distinfo b/x11/xssstate/distinfo
+new file mode 100644
+index 000000000000..6bb09a7a56f9
+--- /dev/null
++++ b/x11/xssstate/distinfo
+@@ -0,0 +1,3 @@
++TIMESTAMP = 1610705062
++SHA256 (xssstate-1.1.tar.gz) = c4b6f504a6a8eb247bc60960bd65cbf9631c008449a1d71ac4c55e34be1c6011
++SIZE (xssstate-1.1.tar.gz) = 3725
+diff --git a/x11/xssstate/pkg-descr b/x11/xssstate/pkg-descr
+new file mode 100644
+index 000000000000..01b1d2e662f1
+--- /dev/null
++++ b/x11/xssstate/pkg-descr
+@@ -0,0 +1,5 @@
++xssstate is a simple tool to retrieve the X screensaver extension state.
++It could show the idle time of X11, the current state whether on, off, or
++disabled, and also the required time for screensaver activation.
++
++WWW: https://tools.suckless.org/x/xssstate


### PR DESCRIPTION
```
new port: x11/xssstate: a simple tool to retrieve the X screensaver state

Submitted by: Faraz Vahedi <kfv_irbug.org>
Approved by: lwhsu
Differential Revision: https://reviews.freebsd.org/D28174