### PR TITLE
security/R-cran-credentials:1.3.0

### DIFF
--- a/patches/security.R-cran-credentials.1.3.0.diff
+++ b/patches/security.R-cran-credentials.1.3.0.diff
@@ -1,0 +1,63 @@
+diff --git a/security/Makefile b/security/Makefile
+index 8a554120d73b..2634205d1f95 100644
+--- a/security/Makefile
++++ b/security/Makefile
+@@ -7,6 +7,7 @@
+     SUBDIR += ADMsnmp
+     SUBDIR += R-cran-ROAuth
+     SUBDIR += R-cran-askpass
++    SUBDIR += R-cran-credentials
+     SUBDIR += R-cran-digest
+     SUBDIR += R-cran-gitcreds
+     SUBDIR += R-cran-openssl
+diff --git a/security/R-cran-credentials/Makefile b/security/R-cran-credentials/Makefile
+new file mode 100644
+index 000000000000..5561add627ca
+--- /dev/null
++++ b/security/R-cran-credentials/Makefile
+@@ -0,0 +1,21 @@
++# Created by: Guangyuan Yang <ygy@FreeBSD.org>
++
++PORTNAME=	credentials
++DISTVERSION=	1.3.0
++CATEGORIES=	security
++DISTNAME=	${PORTNAME}_${DISTVERSION}
++
++MAINTAINER=	ygy@FreeBSD.org
++COMMENT=	Tools for Managing SSH and Git Credentials
++
++LICENSE=	MIT
++LICENSE_FILE=	${WRKSRC}/LICENSE
++
++BUILD_DEPENDS=	R-cran-knitr>0:print/R-cran-knitr
++TEST_DEPENDS=	R-cran-testthat>0:devel/R-cran-testthat \
++		R-cran-knitr>0:print/R-cran-knitr \
++		R-cran-rmarkdown>0:textproc/R-cran-rmarkdown
++
++USES=		cran:auto-plist
++
++.include <bsd.port.mk>
+diff --git a/security/R-cran-credentials/distinfo b/security/R-cran-credentials/distinfo
+new file mode 100644
+index 000000000000..9bfcc415b12b
+--- /dev/null
++++ b/security/R-cran-credentials/distinfo
+@@ -0,0 +1,3 @@
++TIMESTAMP = 1620162645
++SHA256 (credentials_1.3.0.tar.gz) = c119ec26fd97b977c3b0cd1eb8fad3c59b84df6262c3adbf5ee9f3d6c9903ff1
++SIZE (credentials_1.3.0.tar.gz) = 230082
+diff --git a/security/R-cran-credentials/pkg-descr b/security/R-cran-credentials/pkg-descr
+new file mode 100644
+index 000000000000..326cc0be403f
+--- /dev/null
++++ b/security/R-cran-credentials/pkg-descr
+@@ -0,0 +1,9 @@
++Setup and retrieve HTTPS and SSH credentials for use with 'git' and other
++services. For HTTPS remotes the package interfaces the 'git-credential' utility
++which 'git' uses to store HTTP usernames and passwords. For SSH remotes we
++provide convenient functions to find or generate appropriate SSH keys. The
++package both helps the user to setup a local git installation, and also
++provides a back-end for git/ssh client libraries to authenticate with existing
++user credentials.
++
++WWW: https://docs.ropensci.org/credentials


### PR DESCRIPTION
```
new port: security/R-cran-credentials: Tools for Managing SSH and Git Credentials

Approved by: lwhsu