### PR TITLE
math/R-cran-gsl:2.1-6

### DIFF
--- a/patches/math.R-cran-gsl.2.1-6.diff
+++ b/patches/math.R-cran-gsl.2.1-6.diff
@@ -1,0 +1,54 @@
+diff --git a/math/Makefile b/math/Makefile
+index 7fa4c3f3da04..06d04ecdb514 100644
+--- a/math/Makefile
++++ b/math/Makefile
+@@ -62,6 +62,7 @@
+     SUBDIR += R-cran-gmp
+     SUBDIR += R-cran-gower
+     SUBDIR += R-cran-gpclib
++    SUBDIR += R-cran-gsl
+     SUBDIR += R-cran-gss
+     SUBDIR += R-cran-gtable
+     SUBDIR += R-cran-haven
+diff --git a/math/R-cran-gsl/Makefile b/math/R-cran-gsl/Makefile
+new file mode 100644
+index 000000000000..b2bbf6763acc
+--- /dev/null
++++ b/math/R-cran-gsl/Makefile
+@@ -0,0 +1,18 @@
++# Created by: Guangyuan Yang <ygy@FreeBSD.org>
++# $FreeBSD$
++
++PORTNAME=	gsl
++DISTVERSION=	2.1-6
++CATEGORIES=	math
++DISTNAME=	${PORTNAME}_${DISTVERSION}
++
++MAINTAINER=	ygy@FreeBSD.org
++COMMENT=	Wrapper for the Gnu Scientific Library
++
++LICENSE=	GPLv3
++
++LIB_DEPENDS=	libgsl.so:math/gsl
++
++USES=		cran:auto-plist,compiles
++
++.include <bsd.port.mk>
+diff --git a/math/R-cran-gsl/distinfo b/math/R-cran-gsl/distinfo
+new file mode 100644
+index 000000000000..3a7c375785f3
+--- /dev/null
++++ b/math/R-cran-gsl/distinfo
+@@ -0,0 +1,3 @@
++TIMESTAMP = 1614270213
++SHA256 (gsl_2.1-6.tar.gz) = f5d463239693f146617018987687db31b163653708cbae0b730b9b7bed81995c
++SIZE (gsl_2.1-6.tar.gz) = 189794
+diff --git a/math/R-cran-gsl/pkg-descr b/math/R-cran-gsl/pkg-descr
+new file mode 100644
+index 000000000000..1547eb74a53c
+--- /dev/null
++++ b/math/R-cran-gsl/pkg-descr
+@@ -0,0 +1,3 @@
++An R wrapper for some of the functionality of the Gnu Scientific Library.
++
++WWW: https://github.com/RobinHankin/gsl.git


### PR DESCRIPTION
```
new port: math/R-cran-gsl: R Wrapper for the Gnu Scientific Library

Approved by: lwhsu