### PR TITLE
devel/R-cran-gert:1.3.0

### DIFF
--- a/patches/devel.R-cran-gert.1.3.0.diff
+++ b/patches/devel.R-cran-gert.1.3.0.diff
@@ -1,0 +1,62 @@
+diff --git a/devel/Makefile b/devel/Makefile
+index daf7feb5b66c..1d3406261f33 100644
+--- a/devel/Makefile
++++ b/devel/Makefile
+@@ -46,6 +46,7 @@
+     SUBDIR += R-cran-gbm
+     SUBDIR += R-cran-gdata
+     SUBDIR += R-cran-generics
++    SUBDIR += R-cran-gert
+     SUBDIR += R-cran-getopt
+     SUBDIR += R-cran-git2r
+     SUBDIR += R-cran-glmnet
+diff --git a/devel/R-cran-gert/Makefile b/devel/R-cran-gert/Makefile
+new file mode 100644
+index 000000000000..7d59a7ec5bbb
+--- /dev/null
++++ b/devel/R-cran-gert/Makefile
+@@ -0,0 +1,22 @@
++# Created by: Guangyuan Yang <ygy@FreeBSD.org>
++
++PORTNAME=	gert
++DISTVERSION=	1.3.0
++CATEGORIES=	devel
++DISTNAME=	${PORTNAME}_${DISTVERSION}
++
++MAINTAINER=	ygy@FreeBSD.org
++COMMENT=	Simple Git Client for R
++
++LICENSE=	MIT
++LICENSE_FILE=	${WRKSRC}/LICENSE
++
++BUILD_DEPENDS=	R-cran-knitr>0:print/R-cran-knitr
++RUN_DEPENDS=	R-cran-askpass>0:security/R-cran-askpass
++TEST_DEPENDS=	R-cran-testthat>0:devel/R-cran-testthat \
++		R-cran-knitr>0:print/R-cran-knitr \
++		R-cran-rmarkdown>0:textproc/R-cran-rmarkdown
++
++USES=		cran:auto-plist,compiles
++
++.include <bsd.port.mk>
+diff --git a/devel/R-cran-gert/distinfo b/devel/R-cran-gert/distinfo
+new file mode 100644
+index 000000000000..9d970fb0e573
+--- /dev/null
++++ b/devel/R-cran-gert/distinfo
+@@ -0,0 +1,3 @@
++TIMESTAMP = 1620698552
++SHA256 (gert_1.3.0.tar.gz) = 071229134517b47ef710fc5586a27458be308daef21cc8c2f603492ed21507ba
++SIZE (gert_1.3.0.tar.gz) = 66410
+diff --git a/devel/R-cran-gert/pkg-descr b/devel/R-cran-gert/pkg-descr
+new file mode 100644
+index 000000000000..c8911b8e2ace
+--- /dev/null
++++ b/devel/R-cran-gert/pkg-descr
+@@ -0,0 +1,7 @@
++Simple git client for R based on 'libgit2' with support for SSH and HTTPS
++remotes. All functions in 'gert' use basic R data types (such as vectors and
++data-frames) for their arguments and return values. User credentials are shared
++with command line 'git' through the git-credential store and ssh keys stored on
++disk or ssh-agent.
++
++WWW: https://docs.ropensci.org/gert/


### PR DESCRIPTION
```
new port: devel/R-cran-gert: Simple Git Client for R

Approved by: lwhsu